### PR TITLE
feat(reader): swipe down to re-fetch a chapter, never cache empty res…

### DIFF
--- a/assets/reader/js/core.js
+++ b/assets/reader/js/core.js
@@ -908,6 +908,15 @@ window.addEventListener('load', () => {
       return;
     }
     if (
+      diffY > 80 &&
+      Math.abs(diffY) > Math.abs(diffX) * 2 &&
+      window.scrollY <= 0
+    ) {
+      e.preventDefault();
+      reader.post({ type: 'refresh' });
+      return;
+    }
+    if (
       reader.generalSettings.val.swipeGestures &&
       Math.abs(diffX) > Math.abs(diffY) * 2 &&
       Math.abs(diffX) > 180

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 const { defineConfig, globalIgnores } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 const { FlatCompat } = require('@eslint/eslintrc');
+const tseslint = require('@typescript-eslint/eslint-plugin');
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
@@ -19,6 +20,7 @@ module.exports = defineConfig([
     '.expo/**',
     'dist/**',
     'coverage/**',
+    'assets/**',
   ]),
   expoConfig,
   ...compat
@@ -30,6 +32,9 @@ module.exports = defineConfig([
 
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
     rules: {
       'no-shadow': 'off',
       'no-undef': 'off',

--- a/src/i18n/languages/en/strings.json
+++ b/src/i18n/languages/en/strings.json
@@ -671,7 +671,7 @@
       "scrollToCurrentChapter": "Scroll to current chapter",
       "scrollToTop": "Scroll to top"
     },
-    "emptyChapterMessage": "<h2>Chapter couldn't be loaded</h2><p>No readable content was found. Check the chapter in WebView; if it loads there, <a href='%{reportUrl}'>report the plugin issue</a>.</p><p>Plugin: %{pluginId}<br>Novel: %{novelName}<br>Chapter: %{chapterName}</p>",
+    "emptyChapterMessage": "<h2>Chapter couldn't be loaded</h2><p>No readable content was found. Check the chapter in WebView; if it loads there, <a href='%{reportUrl}'>report the plugin issue</a>.</p><p><a href='%{refreshUrl}'>Refresh chapter</a></p><p>Plugin: %{pluginId}<br>Novel: %{novelName}<br>Chapter: %{chapterName}</p>",
     "finished": "Finished",
     "nextChapter": "Next: %{name}",
     "noNextChapter": "There's no next chapter",

--- a/src/screens/reader/components/ReaderFooter.tsx
+++ b/src/screens/reader/components/ReaderFooter.tsx
@@ -66,7 +66,8 @@ const ChapterFooter = ({
   scrollToStart,
   openDrawer,
 }: ChapterFooterProps) => {
-  const { nextChapter, prevChapter, navigateChapter } = useChapterContext();
+  const { nextChapter, prevChapter, navigateChapter, refetch } =
+    useChapterContext();
   const theme = useTheme();
   const rippleConfig = {
     color: theme.rippleColor,
@@ -123,6 +124,13 @@ const ChapterFooter = ({
             size={26}
             iconColor={theme.onSurface}
           />
+        </Pressable>
+        <Pressable
+          android_ripple={rippleConfig}
+          style={styles.buttonStyles}
+          onPress={() => refetch()}
+        >
+          <IconButton icon="refresh" size={26} iconColor={theme.onSurface} />
         </Pressable>
         <Pressable
           android_ripple={rippleConfig}

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -33,7 +33,10 @@ import { Dialog } from '@components/Dialog';
 import { TextInput } from 'react-native-paper';
 import useCustomCode from './Hooks/useCustomCode';
 import useTextModifications from './Hooks/useTextModifications';
-import { isPluginIssueReportUrl } from '../utils/sanitizeChapterText';
+import {
+  isChapterRefreshUrl,
+  isPluginIssueReportUrl,
+} from '../utils/sanitizeChapterText';
 
 export type WebViewPostEvent = {
   type: string;
@@ -138,6 +141,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     webViewRef,
     onUserInteraction,
     isTTSReadingRef,
+    refetch,
   } = useChapterContext();
   const theme = useTheme();
   const initialReaderSettings = useMemo(
@@ -458,6 +462,10 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
           void Linking.openURL(url);
           return false;
         }
+        if (isChapterRefreshUrl(url)) {
+          refetch();
+          return false;
+        }
         return true;
       }}
       onLoadEnd={() => {
@@ -551,6 +559,9 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
             }
             case 'hide':
               onPress();
+              break;
+            case 'refresh':
+              refetch();
               break;
             case 'next':
               nextChapterScreenVisible.current = true;

--- a/src/screens/reader/hooks/__tests__/useChapter.test.ts
+++ b/src/screens/reader/hooks/__tests__/useChapter.test.ts
@@ -352,6 +352,28 @@ describe('useChapter', () => {
     );
   });
 
+  it('drops an empty chapter from the cache so a refresh refetches', async () => {
+    const store = createStore();
+    mockUseNovelActions.mockReturnValue(store.state);
+    mockFetchChapter.mockResolvedValueOnce('   ');
+
+    const { result } = renderHook(() => useFlatChapter(initialChapter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chapterText).toBe('SANITIZED:   ');
+    expect(store.chapterTextCache.read(initialChapter.id)).toBeUndefined();
+
+    mockFetchChapter.mockResolvedValue('recovered body');
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() =>
+      expect(result.current.chapterText).toBe('SANITIZED:recovered body'),
+    );
+    expect(mockFetchChapter).toHaveBeenCalledTimes(2);
+  });
+
   it('reuses prefetched promise cache to avoid duplicate concurrent fetches for same chapter', async () => {
     const store = createStore();
     mockUseNovelActions.mockReturnValue(store.state);

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -172,9 +172,18 @@ export default function useChapter(
         return cached;
       }
 
-      const pending = loadChapterText(chap).then(text =>
-        sanitizeChapterText(novel.pluginId, novel.name, chap.name, text),
-      );
+      const pending = loadChapterText(chap).then(text => {
+        const sanitized = sanitizeChapterText(
+          novel.pluginId,
+          novel.name,
+          chap.name,
+          text,
+        );
+        if (!text.trim()) {
+          chapterTextCache.remove(chap.id);
+        }
+        return sanitized;
+      });
       chapterTextCache.write(chap.id, pending);
       // Never keep a failed load in the cache, otherwise a retry would
       // resolve instantly with the same failure.

--- a/src/screens/reader/utils/__tests__/sanitizeChapterText.test.ts
+++ b/src/screens/reader/utils/__tests__/sanitizeChapterText.test.ts
@@ -1,6 +1,8 @@
 import { getString } from '@i18n/translations';
 
 import {
+  CHAPTER_REFRESH_URL,
+  isChapterRefreshUrl,
   isPluginIssueReportUrl,
   sanitizeChapterText,
 } from '../sanitizeChapterText';
@@ -14,6 +16,7 @@ jest.mock('@i18n/translations', () => ({
         novelName: string;
         chapterName: string;
         reportUrl: string;
+        refreshUrl: string;
       },
     ) =>
       [
@@ -21,6 +24,7 @@ jest.mock('@i18n/translations', () => ({
         options.novelName,
         options.chapterName,
         options.reportUrl,
+        options.refreshUrl,
       ].join('|'),
   ),
 }));
@@ -68,11 +72,13 @@ describe('sanitizeChapterText', () => {
         pluginId: 'plugin.test',
         novelName: 'A &lt;Novel&gt;',
         chapterName: 'Chapter 1 &amp; &quot;After&quot;',
+        refreshUrl: CHAPTER_REFRESH_URL,
       }),
     );
     expect(result).toContain(
       'template=report_issue.yml&amp;title=%5Bplugin.test%5D%20Empty%20chapter%3A%20A%20%3CNovel%3E%20%E2%80%94%20Chapter%201%20%26%20%22After%22',
     );
+    expect(result).toContain(CHAPTER_REFRESH_URL);
   });
 });
 
@@ -88,5 +94,13 @@ describe('isPluginIssueReportUrl', () => {
         'https://github.com/lnreader/lnreader-plugins/issues/new-malicious',
       ),
     ).toBe(false);
+  });
+});
+
+describe('isChapterRefreshUrl', () => {
+  it('matches the refresh-chapter custom scheme', () => {
+    expect(isChapterRefreshUrl(CHAPTER_REFRESH_URL)).toBe(true);
+    expect(isChapterRefreshUrl('lnreader://refresh-chapter?x=1')).toBe(false);
+    expect(isChapterRefreshUrl('https://example.com')).toBe(false);
   });
 });

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -4,9 +4,15 @@ import sanitizeHtml from 'sanitize-html';
 const PLUGIN_ISSUE_REPORT_URL =
   'https://github.com/lnreader/lnreader-plugins/issues/new';
 
+/** Custom scheme intercepted by the reader WebView to re-fetch the chapter. */
+export const CHAPTER_REFRESH_URL = 'lnreader://refresh-chapter';
+
 export const isPluginIssueReportUrl = (url: string): boolean =>
   url === PLUGIN_ISSUE_REPORT_URL ||
   url.startsWith(`${PLUGIN_ISSUE_REPORT_URL}?`);
+
+export const isChapterRefreshUrl = (url: string): boolean =>
+  url === CHAPTER_REFRESH_URL;
 
 const escapeHtml = (value: string): string =>
   value.replace(
@@ -112,6 +118,7 @@ export const sanitizeChapterText = (
       reportUrl: escapeHtml(
         getPluginIssueReportUrl(pluginId, novelName, chapterName),
       ),
+      refreshUrl: escapeHtml(CHAPTER_REFRESH_URL),
     })
   );
 };


### PR DESCRIPTION
…ponses

- pull down at the top of a chapter to re-fetch it, recovering from transient empty responses without leaving the reader
- empty responses are evicted from the chapter cache so a refresh re-fetches instead of replaying the empty message
- add a refresh button to the reader's bottom bar and a 'Refresh chapter' link on the empty-chapter message
- register the typescript-eslint plugin and ignore assets/ in the eslint flat config so lint-staged can lint core.js